### PR TITLE
Chat group response formatting

### DIFF
--- a/orchestration/orchestrator.py
+++ b/orchestration/orchestrator.py
@@ -67,7 +67,38 @@ class Orchestrator:
         return self.agent_creation_strategy.create_agents(self.llm_config, history)
 
     async def _initiate_group_chat(self, agents: list, ask: str) -> dict:
-        """Start the group chat and generate a response."""
+        """
+        Initiates a group chat with multiple agents and generates a response based on the chat interactions.
+        
+        This method creates a group chat instance, manages it using the GroupChatManager, and captures 
+        the chat's execution process, including the agents' thoughts and decisions. It logs various steps 
+        and captures the chat process' output, returning a dictionary with the conversation details, 
+        including the final answer, any data points, and the chat's thought process.
+
+        Args:
+            agents (list): A list of agents participating in the group chat.
+            ask (str): The initial message to start the group chat and guide the conversation.
+
+        Returns:
+            dict: A dictionary containing:
+                - conversation_id (str): A unique identifier for the conversation.
+                - answer (str): The final response generated from the chat.
+                - data_points (str): Any extracted data points from the conversation.
+                - thoughts (str): The captured thought process and output of the agents during the conversation.
+        
+        Logs:
+            Logs various steps of the group chat initiation, including thought processes, warnings, 
+            and potential issues such as content filtering blocks.
+
+        Raises:
+            None: This function does not raise any exceptions, but logs potential issues.
+
+        Notes:
+            - The captured thoughts and stdout redirection allow for insight into the decision-making 
+            process of the agents.
+            - If no valid response is generated or if content filtering occurs, this is handled by 
+            providing an appropriate message in the `answer_dict`.
+        """
         logging.info(f"[orchestrator] {self.short_id} Creating group chat.")
         groupchat = autogen.GroupChat(
             agents=agents, 
@@ -101,12 +132,23 @@ class Orchestrator:
                 "conversation_id": self.conversation_id,
                 "answer": "",
                 "data_points": "",
-                "thoughts": captured_output.getvalue()  # Optional: Capture thought process
+                "thoughts": "Agents group chat:\n\n" + captured_output.getvalue()  # Optional: Capture thought process
             }
             if chat_result and chat_result.summary:
-                answer_dict['answer'] = chat_result.summary
+                # Check if there are at least two messages in the chat history and the second last message is from a tool
                 if len(chat_result.chat_history) >= 2 and chat_result.chat_history[-2]['role'] == 'tool':
+                    # Extract data points from the content of the second last message in the chat history
                     answer_dict['data_points'] = chat_result.chat_history[-2]['content']
+                
+                # Get the summary of the chat result and strip any leading/trailing whitespace
+                chat_answer = chat_result.summary.strip()
+                
+                # If the chat answer ends with a specific marker (e.g., "\n\n****"), remove the marker and strip any trailing whitespace
+                if chat_answer.endswith("\n\n****"):
+                    chat_answer = chat_answer[:-6].strip()
+                
+                # Store the processed chat answer in the answer dictionary
+                answer_dict['answer'] = chat_answer                
             else:
                 logging.info(f"[orchestrator] {self.short_id} No valid response generated.")
                 # Check if there's a warning with content filtering block


### PR DESCRIPTION
This pull request includes significant improvements to the `_initiate_group_chat` method in the `orchestration/orchestrator.py` file. The changes enhance the method's documentation and refine the handling of chat results, including the extraction and processing of data points and chat summaries.

Enhancements to documentation:

* [`orchestration/orchestrator.py`](diffhunk://#diff-74c2720089df3b84604dc2f169a4d93ccdcbb95e1157b4be89f51f21ba83a65bL70-R101): Expanded the docstring for the `_initiate_group_chat` method to provide a detailed description of its functionality, arguments, return values, logging, and notes.

Refinements to chat result handling:

* [`orchestration/orchestrator.py`](diffhunk://#diff-74c2720089df3b84604dc2f169a4d93ccdcbb95e1157b4be89f51f21ba83a65bL104-R151): Updated the `thoughts` field in the `answer_dict` to prepend "Agents group chat:\n\n" to the captured output.
* [`orchestration/orchestrator.py`](diffhunk://#diff-74c2720089df3b84604dc2f169a4d93ccdcbb95e1157b4be89f51f21ba83a65bL104-R151): Added logic to check the chat history for data points and process the chat summary by stripping unnecessary markers and whitespace before storing it in the `answer_dict`.