### PR TITLE
NL2SQLDuoAgentCreationStrategy import error fix

### DIFF
--- a/orchestration/nl2sql_duo_agent_creation_strategy.py
+++ b/orchestration/nl2sql_duo_agent_creation_strategy.py
@@ -31,7 +31,7 @@ class ExecuteSQLResult(BaseModel):
     results: Optional[List[Dict[str, Union[str, int, float, None]]]] = None
     error: Optional[str] = None
 
-class NL2SQLWithReviewAgentCreationStrategy(BaseAgentCreationStrategy):
+class NL2SQLDuoAgentCreationStrategy(BaseAgentCreationStrategy):
 
     def __init__(self):
         super().__init__()


### PR DESCRIPTION
This pull request includes a fix to NL2SQLDuoAgentCreationStrategy import error in AgentCreationStrategyFactory class:

* [`orchestration/nl2sql_duo_agent_creation_strategy.py`](diffhunk://#diff-c32b01545a4b10f2c9dd1a3e80b2b8c3bb4f2dacaf02b7939ee7832163724176L34-R34): Renamed the class `NL2SQLWithReviewAgentCreationStrategy` to `NL2SQLDuoAgentCreationStrategy`.