### PR TITLE
 Replacing DefaultAzureCredential with ChainedTokenCredential

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ openAIAccountName='Azure OpenAI service name'  # Name of the Azure OpenAI servic
 az role assignment create --role "Cognitive Services OpenAI User" --assignee $principalId --scope /subscriptions/$subscriptionId/resourceGroups/$resourceGroupName/providers/Microsoft.CognitiveServices/accounts/$openAIAccountName
 
 # Set variables for Cognitive Search role assignment
-searchServiceName='Azure Cognitive Search service name'  # Name of your Azure Cognitive Search service
+searchServiceName='Azure Cognitive Search service name'  # Name of your Azure AI Search service
 
 # Assign Search Index Data Reader role
 az role assignment create --role "Search Index Data Reader" --assignee $principalId --scope /subscriptions/$subscriptionId/resourceGroups/$resourceGroupName/providers/Microsoft.Search/searchServices/$searchServiceName
@@ -214,7 +214,7 @@ $openAIAccountName='Azure OpenAI service name'  # Name of the Azure OpenAI servi
 az role assignment create --role "Cognitive Services OpenAI User" --assignee $principalId --scope /subscriptions/$subscriptionId/resourceGroups/$resourceGroupName/providers/Microsoft.CognitiveServices/accounts/$openAIAccountName
 
 # Set variables for Cognitive Search role assignment
-$searchServiceName='Azure Cognitive Search service name'  # Name of your Azure Cognitive Search service
+$searchServiceName='Azure Cognitive Search service name'  # Name of your Azure AI Search service
 
 # Assign Search Index Data Reader role
 az role assignment create --role "Search Index Data Reader" --assignee $principalId --scope /subscriptions/$subscriptionId/resourceGroups/$resourceGroupName/providers/Microsoft.Search/searchServices/$searchServiceName

--- a/connectors/aoai.py
+++ b/connectors/aoai.py
@@ -3,7 +3,7 @@ import os
 import tiktoken
 import time
 from openai import AzureOpenAI, RateLimitError
-from azure.identity import DefaultAzureCredential, get_bearer_token_provider
+from azure.identity import ManagedIdentityCredential, AzureCliCredential, ChainedTokenCredential, get_bearer_token_provider
 
 MAX_RETRIES = 10 # Maximum number of retries for rate limit errors
 MAX_EMBEDDINGS_MODEL_INPUT_TOKENS = 8192
@@ -26,7 +26,10 @@ class AzureOpenAIClient:
         self.openai_api_version = os.getenv('AZURE_OPENAI_API_VERSION')
 
         token_provider = get_bearer_token_provider(
-            DefaultAzureCredential(), "https://cognitiveservices.azure.com/.default"
+            ChainedTokenCredential(
+                ManagedIdentityCredential(),
+                AzureCliCredential()
+            ), "https://cognitiveservices.azure.com/.default"
         )
 
         self.client = AzureOpenAI(

--- a/connectors/cosmosdb.py
+++ b/connectors/cosmosdb.py
@@ -2,7 +2,7 @@ import logging
 import os
 import time
 from azure.cosmos.aio import CosmosClient
-from azure.identity.aio import DefaultAzureCredential
+from azure.identity.aio import ManagedIdentityCredential, AzureCliCredential, ChainedTokenCredential
 
 MAX_RETRIES = 10  # Maximum number of retries for rate limit errors
 
@@ -33,7 +33,10 @@ class CosmosDBClient:
 # self.history = self.conversation_data.get('history', [])
 
     async def get_document(self, container, key) -> dict: 
-        async with DefaultAzureCredential() as credential:    
+        async with ChainedTokenCredential(
+                ManagedIdentityCredential(),
+                AzureCliCredential()
+            ) as credential:    
             async with CosmosClient(self.db_uri, credential=credential) as db_client:
                 db = db_client.get_database_client(database=self.db_name)
                 container = db.get_container_client(container)
@@ -46,7 +49,10 @@ class CosmosDBClient:
                 return document
 
     async def create_document(self, container, key) -> dict: 
-        async with DefaultAzureCredential() as credential:    
+        async with ChainedTokenCredential(
+                ManagedIdentityCredential(),
+                AzureCliCredential()
+            ) as credential:    
             async with CosmosClient(self.db_uri, credential=credential) as db_client:
                 db = db_client.get_database_client(database=self.db_name)
                 container = db.get_container_client(container)
@@ -59,7 +65,10 @@ class CosmosDBClient:
                 return document
             
     async def update_document(self, container, document) -> dict: 
-        async with DefaultAzureCredential() as credential:    
+        async with ChainedTokenCredential(
+                ManagedIdentityCredential(),
+                AzureCliCredential()
+            ) as credential:    
             async with CosmosClient(self.db_uri, credential=credential) as db_client:
                 db = db_client.get_database_client(database=self.db_name)
                 container = db.get_container_client(container)

--- a/connectors/keyvault.py
+++ b/connectors/keyvault.py
@@ -1,6 +1,6 @@
 import os
 import logging
-from azure.identity.aio import DefaultAzureCredential as AsyncDefaultAzureCredential
+from azure.identity.aio import ManagedIdentityCredential, AzureCliCredential, ChainedTokenCredential
 from azure.keyvault.secrets.aio import SecretClient as AsyncSecretClient
 from azure.core.exceptions import ResourceNotFoundError, ClientAuthenticationError
 
@@ -12,7 +12,10 @@ async def get_secret(secretName):
     try:
         keyVaultName = os.environ["AZURE_KEY_VAULT_NAME"]
         KVUri = f"https://{keyVaultName}.vault.azure.net"
-        async with AsyncDefaultAzureCredential() as credential:
+        async with ChainedTokenCredential(
+                ManagedIdentityCredential(),
+                AzureCliCredential()
+            ) as credential:
             async with AsyncSecretClient(vault_url=KVUri, credential=credential) as client:
                 retrieved_secret = await client.get_secret(secretName)
                 value = retrieved_secret.value

--- a/docs/LOCAL_DEPLOYMENT.md
+++ b/docs/LOCAL_DEPLOYMENT.md
@@ -52,7 +52,7 @@ openAIAccountName='Azure OpenAI service name'  # Name of the Azure OpenAI servic
 az role assignment create --role "Cognitive Services OpenAI User" --assignee $principalId --scope /subscriptions/$subscriptionId/resourceGroups/$resourceGroupName/providers/Microsoft.CognitiveServices/accounts/$openAIAccountName
 
 # Set variables for Cognitive Search role assignment
-searchServiceName='Azure Cognitive Search service name'  # Name of your Azure Cognitive Search service
+searchServiceName='Azure Cognitive Search service name'  # Name of your Azure AI Search service
 
 # Assign Search Index Data Reader role
 az role assignment create --role "Search Index Data Reader" --assignee $principalId --scope /subscriptions/$subscriptionId/resourceGroups/$resourceGroupName/providers/Microsoft.Search/searchServices/$searchServiceName
@@ -77,7 +77,7 @@ $openAIAccountName='Azure OpenAI service name'  # Name of the Azure OpenAI servi
 az role assignment create --role "Cognitive Services OpenAI User" --assignee $principalId --scope /subscriptions/$subscriptionId/resourceGroups/$resourceGroupName/providers/Microsoft.CognitiveServices/accounts/$openAIAccountName
 
 # Set variables for Cognitive Search role assignment
-$searchServiceName='Azure Cognitive Search service name'  # Name of your Azure Cognitive Search service
+$searchServiceName='Azure AI Search service name'  # Name of your Azure AI Search service
 
 # Assign Search Index Data Reader role
 az role assignment create --role "Search Index Data Reader" --assignee $principalId --scope /subscriptions/$subscriptionId/resourceGroups/$resourceGroupName/providers/Microsoft.Search/searchServices/$searchServiceName

--- a/orchestration/strategies/nl2sql_advisor_strategy.py
+++ b/orchestration/strategies/nl2sql_advisor_strategy.py
@@ -1,8 +1,3 @@
-import logging
-import struct
-import os
-import pyodbc
-from azure.identity import DefaultAzureCredential
 from autogen import UserProxyAgent, AssistantAgent, register_function
 from .nl2sql_base_agent_strategy import NL2SQLBaseStrategy
 from ..constants import NL2SQL_ADVISOR

--- a/tools/retrieval/columns_retrieval.py
+++ b/tools/retrieval/columns_retrieval.py
@@ -1,7 +1,7 @@
 from typing import List, Dict
 from typing_extensions import Annotated
 from connectors import AzureOpenAIClient
-from azure.identity import DefaultAzureCredential
+from azure.identity import ManagedIdentityCredential, AzureCliCredential, ChainedTokenCredential
 import os
 import time
 import logging
@@ -42,7 +42,10 @@ def columns_retrieval(
     search_results: List[Dict[str, str]] = []
     search_query = f"{user_ask} table:{table_name}"
     try:
-        credential = DefaultAzureCredential()
+        credential = ChainedTokenCredential(
+                ManagedIdentityCredential(),
+                AzureCliCredential()
+            )
         start_time = time.time()
         logging.info(f"[ai_search] Generating question embeddings. Search query: {search_query}")
         embeddings_query = aoai.get_embeddings(search_query)

--- a/tools/retrieval/queries_retrieval.py
+++ b/tools/retrieval/queries_retrieval.py
@@ -1,6 +1,6 @@
 from typing_extensions import Annotated
 from connectors import AzureOpenAIClient
-from azure.identity import DefaultAzureCredential
+from azure.identity import ManagedIdentityCredential, AzureCliCredential, ChainedTokenCredential
 import os
 import time
 import logging
@@ -29,7 +29,10 @@ def queries_retrieval(
     search_results = []
     search_query = input
     try:
-        credential = DefaultAzureCredential()
+        credential = ChainedTokenCredential(
+                ManagedIdentityCredential(),
+                AzureCliCredential()
+            )
         start_time = time.time()
         logging.info(f"[ai_search] Generating question embeddings. Search query: {search_query}")
         embeddings_query = aoai.get_embeddings(search_query)

--- a/tools/retrieval/tables_retrieval.py
+++ b/tools/retrieval/tables_retrieval.py
@@ -1,7 +1,7 @@
 from typing import List, Dict
 from typing_extensions import Annotated
 from connectors import AzureOpenAIClient
-from azure.identity import DefaultAzureCredential
+from azure.identity import ManagedIdentityCredential, AzureCliCredential, ChainedTokenCredential
 import os
 import time
 import logging
@@ -40,7 +40,10 @@ def tables_retrieval(
     search_results: List[Dict[str, str]] = []
     search_query = input
     try:
-        credential = DefaultAzureCredential()
+        credential = ChainedTokenCredential(
+                ManagedIdentityCredential(),
+                AzureCliCredential()
+            )
         start_time = time.time()
         logging.info(f"[ai_search] Generating question embeddings. Search query: {search_query}")
         embeddings_query = aoai.get_embeddings(search_query)

--- a/tools/retrieval/vector_index_retrieval.py
+++ b/tools/retrieval/vector_index_retrieval.py
@@ -1,6 +1,6 @@
 from typing_extensions import Annotated
 from connectors import AzureOpenAIClient
-from azure.identity import DefaultAzureCredential
+from azure.identity import ManagedIdentityCredential, AzureCliCredential, ChainedTokenCredential
 import os
 import time
 import logging
@@ -26,7 +26,10 @@ def vector_index_retrieve(
     search_results = []
     search_query = input
     try:
-        credential = DefaultAzureCredential()
+        credential = ChainedTokenCredential(
+                ManagedIdentityCredential(),
+                AzureCliCredential()
+            )
         start_time = time.time()
         logging.info(f"[ai_search] generating question embeddings. search query: {search_query}")
         embeddings_query = aoai.get_embeddings(search_query)


### PR DESCRIPTION
This pull request includes several updates to improve the authentication mechanism by replacing `DefaultAzureCredential` with `ChainedTokenCredential` for better flexibility and reliability. Additionally, it updates documentation and adds new functions to check Azure login status in evaluation scripts.

### Authentication Updates:

* [`connectors/aoai.py`](diffhunk://#diff-9dd3feda1e3c27968cd4c9ce788a41c96eb3656c8982e8fa01addb9d5ad05d0aL6-R6): Replaced `DefaultAzureCredential` with `ChainedTokenCredential` using `ManagedIdentityCredential` and `AzureCliCredential` for obtaining tokens. [[1]](diffhunk://#diff-9dd3feda1e3c27968cd4c9ce788a41c96eb3656c8982e8fa01addb9d5ad05d0aL6-R6) [[2]](diffhunk://#diff-9dd3feda1e3c27968cd4c9ce788a41c96eb3656c8982e8fa01addb9d5ad05d0aL29-R32)
* [`connectors/cosmosdb.py`](diffhunk://#diff-b1b17c4d9d5097dbe077d621ea06cf1a0311b23efd166f741e7a00d139c30fd2L5-R5): Updated credential acquisition to use `ChainedTokenCredential` in all relevant methods. [[1]](diffhunk://#diff-b1b17c4d9d5097dbe077d621ea06cf1a0311b23efd166f741e7a00d139c30fd2L5-R5) [[2]](diffhunk://#diff-b1b17c4d9d5097dbe077d621ea06cf1a0311b23efd166f741e7a00d139c30fd2L36-R39) [[3]](diffhunk://#diff-b1b17c4d9d5097dbe077d621ea06cf1a0311b23efd166f741e7a00d139c30fd2L49-R55) [[4]](diffhunk://#diff-b1b17c4d9d5097dbe077d621ea06cf1a0311b23efd166f741e7a00d139c30fd2L62-R71)
* [`connectors/keyvault.py`](diffhunk://#diff-12a6fc7ef1f3e61a637775efd970788b8ad7411e92d6c070eace95afe0bff652L3-R3): Replaced `AsyncDefaultAzureCredential` with `ChainedTokenCredential` for asynchronous secret retrieval. [[1]](diffhunk://#diff-12a6fc7ef1f3e61a637775efd970788b8ad7411e92d6c070eace95afe0bff652L3-R3) [[2]](diffhunk://#diff-12a6fc7ef1f3e61a637775efd970788b8ad7411e92d6c070eace95afe0bff652L15-R18)
* [`connectors/sqldbs.py`](diffhunk://#diff-04c80b44716ed26d50dc50e8d54056864e55e973f6fd63a7a352028286ba49c3L6-R6): Updated token acquisition to use `ChainedTokenCredential` for both SQL database and fabric connections. [[1]](diffhunk://#diff-04c80b44716ed26d50dc50e8d54056864e55e973f6fd63a7a352028286ba49c3L6-R6) [[2]](diffhunk://#diff-04c80b44716ed26d50dc50e8d54056864e55e973f6fd63a7a352028286ba49c3L52-R55) [[3]](diffhunk://#diff-04c80b44716ed26d50dc50e8d54056864e55e973f6fd63a7a352028286ba49c3L74-R81)
* [`tools/retrieval/*.py`](diffhunk://#diff-871e42d5e95afe7d09e81e51d9132675d8b6ed8b0e9883eb498d73f29581ee21L4-R4): Replaced `DefaultAzureCredential` with `ChainedTokenCredential` in various retrieval scripts for obtaining tokens. [[1]](diffhunk://#diff-871e42d5e95afe7d09e81e51d9132675d8b6ed8b0e9883eb498d73f29581ee21L4-R4) [[2]](diffhunk://#diff-871e42d5e95afe7d09e81e51d9132675d8b6ed8b0e9883eb498d73f29581ee21L45-R48) [[3]](diffhunk://#diff-8b5bc2dd8b7903ed05d4b49ac5096fbd023043ae46dba61fc7a4eb9485789752L3-R3) [[4]](diffhunk://#diff-8b5bc2dd8b7903ed05d4b49ac5096fbd023043ae46dba61fc7a4eb9485789752L32-R35) [[5]](diffhunk://#diff-744f06102be6d018b4b421ad3acc0d04926a016ab9781ca69deaf4f19ebf7049L4-R4) [[6]](diffhunk://#diff-744f06102be6d018b4b421ad3acc0d04926a016ab9781ca69deaf4f19ebf7049L43-R46) [[7]](diffhunk://#diff-49cb0c6798130f7a693335ed03fc230e8712171bbe10cbb1e99e43c59bbc6bcfL3-R3) [[8]](diffhunk://#diff-49cb0c6798130f7a693335ed03fc230e8712171bbe10cbb1e99e43c59bbc6bcfL29-R32)

### Documentation Updates:

* `README.md` and `docs/LOCAL_DEPLOYMENT.md`: Updated comments to reflect the change from "Azure Cognitive Search service" to "Azure AI Search service". [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L192-R192) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L217-R217) [[3]](diffhunk://#diff-c79519d2609bc70c20c082a1fdbf47dfca79e43ec4342b8b9dba87f46be94096L55-R55) [[4]](diffhunk://#diff-c79519d2609bc70c20c082a1fdbf47dfca79e43ec4342b8b9dba87f46be94096L80-R80)

### Evaluation Script Enhancements:

* `evaluations/evaluate.ps1` and `evaluations/evaluate.sh`: Added functions to check if the user is logged into Azure and prompt them to log in if not. [[1]](diffhunk://#diff-252b0e7185d8f0c30c2745ba05c02e85cab53279d88d0a7ceee84152824b2e32R10-R29) [[2]](diffhunk://#diff-cd88a7ee589ecd6d09f4de32863b65e137664d92659c729ad9c2f6affbfe3a9fR12-R25)

These changes enhance the robustness of the authentication process and ensure that users are properly authenticated before running evaluations.