### PR TITLE
table

### DIFF
--- a/tools/database/tables.py
+++ b/tools/database/tables.py
@@ -97,7 +97,7 @@ async def get_all_tables_info(
     body = {
         "search": "*",
         "filter": filter_expression,
-        "select": "table_name, description, datasource",
+        "select": "table, description, datasource",
         "top": 1000  # Adjust based on your expected document count.
     }
 
@@ -113,7 +113,7 @@ async def get_all_tables_info(
 
         for doc in result.get("value", []):
             table_item = TableItem(
-                table=doc.get("table_name", ""),
+                table=doc.get("table", ""),
                 description=doc.get("description", ""),
                 datasource=doc.get("datasource", "")
             )
@@ -148,12 +148,12 @@ async def get_schema_info(
     search_index = "nl2sql-tables"
     safe_datasource = datasource.replace("'", "''")
     safe_table_name = table_name.replace("'", "''")
-    filter_expression = f"datasource eq '{safe_datasource}' and table_name eq '{safe_table_name}'"
+    filter_expression = f"datasource eq '{safe_datasource}' and table eq '{safe_table_name}'"
 
     body = {
         "search": "*",
         "filter": filter_expression,
-        "select": "table_name, description, datasource, columns",
+        "select": "table, description, datasource, columns",
         "top": 1
     }
 
@@ -171,7 +171,7 @@ async def get_schema_info(
             error_message = f"Table '{table_name}' not found in datasource '{datasource}'."
             return SchemaInfo(
                 datasource=datasource,
-                table=table_name,
+                table=table,
                 error=error_message,
                 columns=None
             )
@@ -188,7 +188,7 @@ async def get_schema_info(
 
         return SchemaInfo(
             datasource=datasource,
-            table=doc.get("table_name", table_name),
+            table=doc.get("table", table_name),
             description=doc.get("description", ""),
             columns=columns
         )
@@ -238,7 +238,7 @@ async def tables_retrieval(
 
         # Prepare the request body.
         body: Dict[str, Any] = {
-            "select": "table_name, description",
+            "select": "table, description",
             "top": search_top_k
         }
         # Apply datasource filter if provided.
@@ -279,10 +279,10 @@ async def tables_retrieval(
         if result.get("value"):
             logging.info(f"[tables] {len(result['value'])} documents retrieved")
             for doc in result["value"]:
-                table_name = doc.get("table_name", "")
+                table_name = doc.get("table", "")
                 description = doc.get("description", "")
                 search_results.append(TableRetrievalItem(
-                    table_name=table_name,
+                    table=table_name,
                     description=description,
                     datasource=datasource
                 ))

--- a/tools/database/types.py
+++ b/tools/database/types.py
@@ -124,7 +124,7 @@ class TableRetrievalItem(BaseModel):
     """
     Represents a single table entry with its name, description, and datasource.
     """
-    table_name: str = Field(..., description="The name of the table")
+    table: str = Field(..., description="The name of the table")
     description: str = Field(..., description="A brief description of the table")
     datasource: Optional[str] = Field(None, description="The datasource used for retrieval")
 


### PR DESCRIPTION
This pull request includes several changes to the `tools/database/tables.py` and `tools/database/types.py` files to standardize the naming of the `table_name` field to `table`. The changes ensure consistency across the codebase by updating the field name in various functions and classes.

Standardizing field names:

* [`tools/database/tables.py`](diffhunk://#diff-390ac55567656fc9ea715d651c7dfaac4407e0e27912c663bc6cffeb0eb09753L100-R100): Updated the `select` statements in `get_all_tables_info`, `get_schema_info`, and `tables_retrieval` functions to use `table` instead of `table_name`. [[1]](diffhunk://#diff-390ac55567656fc9ea715d651c7dfaac4407e0e27912c663bc6cffeb0eb09753L100-R100) [[2]](diffhunk://#diff-390ac55567656fc9ea715d651c7dfaac4407e0e27912c663bc6cffeb0eb09753L151-R156) [[3]](diffhunk://#diff-390ac55567656fc9ea715d651c7dfaac4407e0e27912c663bc6cffeb0eb09753L241-R241)
* [`tools/database/tables.py`](diffhunk://#diff-390ac55567656fc9ea715d651c7dfaac4407e0e27912c663bc6cffeb0eb09753L116-R116): Modified the retrieval and assignment of the `table` field in the `get_all_tables_info`, `get_schema_info`, and `tables_retrieval` functions. [[1]](diffhunk://#diff-390ac55567656fc9ea715d651c7dfaac4407e0e27912c663bc6cffeb0eb09753L116-R116) [[2]](diffhunk://#diff-390ac55567656fc9ea715d651c7dfaac4407e0e27912c663bc6cffeb0eb09753L174-R174) [[3]](diffhunk://#diff-390ac55567656fc9ea715d651c7dfaac4407e0e27912c663bc6cffeb0eb09753L191-R191) [[4]](diffhunk://#diff-390ac55567656fc9ea715d651c7dfaac4407e0e27912c663bc6cffeb0eb09753L282-R285)
* [`tools/database/types.py`](diffhunk://#diff-4e25c75b690d5ab0e9e13d13d99b5061d0e9631d0a5dba480d20e252bde6fa4cL127-R127): Changed the `table_name` field to `table` in the `TableRetrievalItem` class.