### PR TITLE
fix: Move URL processing inside document loop in vector_index_retrieve

### DIFF
--- a/tools/ragindex/vector_index_retrieval.py
+++ b/tools/ragindex/vector_index_retrieval.py
@@ -152,13 +152,12 @@ async def vector_index_retrieve(
         elapsed = round(time.time() - start_time, 2)
         logging.info(f"[vector_index_retrieve] Finished querying Azure Cognitive Search in {elapsed} seconds")
 
-        url = doc.get('url', '')
-        url = re.sub(r'https://[^/]+\.blob\.core\.windows\.net', '', url)
-
         if response_json.get('value'):
             logging.info(f"[vector_index_retrieve] {len(response_json['value'])} documents retrieved")
             for doc in response_json['value']:
                 content_str = doc.get('content', '').strip()
+                url = doc.get('url', '')
+                url = re.sub(r'https://[^/]+\.blob\.core\.windows\.net', '', url)
                 search_results.append(f"{url}: {content_str}\n")
         else:
             logging.info("[vector_index_retrieve] No documents retrieved")


### PR DESCRIPTION
## Purpose

Fixed a bug in the `vector_index_retrieve` function where URL processing was attempted before the document loop, causing a NameError. The code was trying to access `doc.get('url')` before the `for` loop where `doc` was defined, which would cause the function to fail when trying to process search results.

## Type of change

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Related Backlog Item or Issue

#58 

## Is this change disruptive or does it break existing applications?

```
[ ] Yes
[X] No
```
This is a non-disruptive bug fix that prevents an error from occurring. The change maintains the same functionality but fixes the implementation to work as intended.

## Cross-Repository Dependencies

- [x] [gpt-rag-agentic](https://github.com/azure/gpt-rag) — This is the only repository that needs to be updated
- [ ] [gpt-rag-orchestrator](https://github.com/azure/gpt-rag-orchestrator)
- [ ] [gpt-rag-ingestion](https://github.com/azure/gpt-rag-ingestion)
- [ ] [gpt-rag-frontend](https://github.com/azure/gpt-rag-frontend)

## Does this require changes to project documentation?

If the changes add new functionality, update the documentation accordingly.

```
[ ] Yes
[X] No
```

This is a bug fix that doesn't change any functionality or API, so no documentation updates are required.

## Documentation Link

N/A - This is a bug fix that doesn't add new functionality.

## Code quality checklist

- [X] I verified the changes locally to ensure they work as expected
- [X] I have tested the new functionality and ensured existing features still work
- [ ] I have updated the CHANGELOG.md file to document these changes
- [X] I have reviewed the code for readability, maintainability, and adherence to project conventions
- [ ] I have added at least two reviewers to the Pull Request

## Contributing guidelines

I have reviewed and followed the contributing guidelines in [CONTRIBUTING.md](https://github.com/Azure/GPT-RAG/blob/main/CONTRIBUTING.md).