### PR TITLE
fix: Use table_name instead of undefined table in get_schema_info error case

### DIFF
--- a/tools/database/tables.py
+++ b/tools/database/tables.py
@@ -171,7 +171,7 @@ async def get_schema_info(
             error_message = f"Table '{table_name}' not found in datasource '{datasource}'."
             return SchemaInfo(
                 datasource=datasource,
-                table=table,
+                table=table_name,
                 error=error_message,
                 columns=None
             )


### PR DESCRIPTION
- Fixes a NameError in get_schema_info when handling non-existent table case
- Replaces undefined 'table' variable with the correct 'table_name' parameter
- Ensures proper error handling when a table is not found in the datasource The bug occurred because the code was trying to use an undefined 'table' variable in the error case return statement, which would cause a NameError when trying to handle the "table not found" case.

## Purpose

Fixed a bug in the `get_schema_info` function where an undefined variable was used in the error case return statement. This would cause a NameError when trying to handle cases where a table is not found in the datasource.

## Type of change


```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Related Backlog Item or Issue

No related issue exists yet. This is a bug report and fix.

## Is this change disruptive or does it break existing applications?

```
[ ] Yes
[X] No
```


## Cross-Repository Dependencies

If this change depends on pull requests in other repositories within the solution, provide the links below.

- [ ] [gpt-rag-agentic](https://github.com/azure/gpt-rag) <!-- Example: — Link: https://github.com/placerda/gpt-rag/pull/456 -->
- [ ] [gpt-rag-orchestrator](https://github.com/azure/gpt-rag-orchestrator) <!-- Example: — Link: https://github.com/placerda/gpt-rag-orchestrator/pull/456 -->
- [ ] [gpt-rag-ingestion](https://github.com/azure/gpt-rag-ingestion) <!-- Example: — Link: https://github.com/placerda/gpt-rag-ingestion/pull/456 -->
- [ ] [gpt-rag-frontend](https://github.com/azure/gpt-rag-frontend) <!-- Example: — Link: https://github.com/placerda/gpt-rag-frontend/pull/456 -->

## Does this require changes to project documentation?

If the changes add new functionality, update the documentation accordingly.

```
[ ] Yes
[ ] No
```

## Documentation Link

If this change adds a new functionality, provide a link to its documentation.

<!-- Example: https://github.com/placerda/gpt-rag-orchestrator/wiki/New-Feature-Guide -->

## Code quality checklist

- [ ] I verified the changes locally to ensure they work as expected
- [ ] I have tested the new functionality and ensured existing features still work
- [ ] I have updated the CHANGELOG.md file to document these changes
- [ ] I have reviewed the code for readability, maintainability, and adherence to project conventions
- [ ] I have added at least two reviewers to the Pull Request

## Contributing guidelines

See [CONTRIBUTING.md](https://github.com/Azure/GPT-RAG/blob/main/CONTRIBUTING.md) for more details.
